### PR TITLE
Implement `append(::Empty{T}, x)`

### DIFF
--- a/src/NoBang/emptycontainers.jl
+++ b/src/NoBang/emptycontainers.jl
@@ -62,6 +62,9 @@ struct Empty{T} end
 Empty(T::Type) = Empty{T}()
 
 push(::Empty{T}, x) where T = singletonof(T, x)
+append(::Empty{T}, x) where T = T(x)
+# In `append`, it is assumed that `T(x::Vector)` works (as done in the
+# implementation of `singletonof`).
 
 Base.IteratorSize(::Type{<:Empty}) = Base.HasLength()
 Base.IteratorEltype(::Type{<:Empty}) = Base.HasEltype()

--- a/test/test_append.jl
+++ b/test/test_append.jl
@@ -2,6 +2,22 @@ module TestAppend
 
 include("preamble.jl")
 
+using BangBang.NoBang: SingletonVector
+using StructArrays: StructVector
+
+"""
+    ==ₜ(x, y)
+
+Check that _type_ and value of `x` and `y` are equal.
+"""
+==ₜ(_, _) = false
+==ₜ(x::T, y::T) where T = x == y
+
+@testset "==ₜ" begin
+    @test 1 ==ₜ 1
+    @test !(1.0 ==ₜ 1)
+end
+
 @testset begin
     @test append!!([0.0], [1.0]) == [0.0, 1.0]
     @test append!!([0], [1.0]) == [0.0, 1.0]
@@ -13,6 +29,29 @@ include("preamble.jl")
     @test append!!("a", "b") === "ab"
     @test append!!(SVector(0), [1])::Vector == [0, 1]
     @test append!!([0], SVector(1))::Vector == [0, 1]
+end
+
+@testset "Empty" begin
+    @testset "`append!!` must create a new collection" begin
+        xs = [1]
+        @test append!!(Empty(Vector), xs) !== xs
+        @test append!!(Empty(Vector), xs) == xs
+    end
+    @testset "`mapreduce`" begin
+        @test mapreduce(
+            SingletonVector,
+            append!!,
+            Any[1, 2, 3];
+            init = Empty(Vector),
+        ) ==ₜ [1, 2, 3]
+
+        @test mapreduce(
+            x -> SingletonVector((a = x, b = x^2)),
+            append!!,
+            [1, 2, 3];
+            init = Empty(StructVector),
+        ) ==ₜ StructVector(a = [1, 2, 3], b = [1, 2, 3] .^ 2)
+    end
 end
 
 end  # module


### PR DESCRIPTION
This is required for implementing `Transducers.tcopy`.