### PR TITLE
Fix Travis CI not running tests with Julia 1.0 and building docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ os:
 julia:
   - 1.3
   - nightly
-matrix:
-  allow_failures:
-    - julia: nightly
-  fast_finish: true
 notifications:
   email: false
 
@@ -27,7 +23,11 @@ script:
   - julia -e 'using Run; Run.test(inline=false)'
 after_success:
   - julia -e 'using Run; Run.after_success_test()'
+
 jobs:
+  allow_failures:
+    - julia: nightly
+  fast_finish: true
   include:
     - name: Test with old dependencies
       julia: 1.0


### PR DESCRIPTION
Travis CI is not running Julia 1.0 anymore with the previous setup.

For example:
https://travis-ci.com/tkf/BangBang.jl/builds/145029429 (for https://github.com/tkf/BangBang.jl/commit/514e8b2d64fd42d836a2613a8b5b2c1cf24b68c2)

Previously it was working:
https://travis-ci.com/tkf/BangBang.jl/builds/144459478 (for https://github.com/tkf/BangBang.jl/commit/d0398a14ebc8a9be1b7ee6c02b13de9c36af91cf)
