### PR TITLE
Fix (define) union!!(::Empty, ::Empty)

### DIFF
--- a/src/NoBang/emptycontainers.jl
+++ b/src/NoBang/emptycontainers.jl
@@ -75,6 +75,7 @@ append(e::Empty, ::Empty) = e
 _empty(x::Empty) = x
 
 _union(::Empty{T}, x) where {T} = unique!!(T(x))
+_union(e::Empty, ::Empty) = e
 
 _setindex(::Empty{T}, v, k) where {T <: AbstractDict} = T(SingletonDict(k, v))
 Base.get(::Empty, _, default) = default

--- a/test/test_union.jl
+++ b/test/test_union.jl
@@ -12,6 +12,13 @@ using BangBang: SingletonVector
     @test union!!(Empty(Set), SingletonVector(0)) ==ₜ Set([0])
 end
 
+@testset "Empty" begin
+    @testset "union!!(::Empty, ::Empty) :: Empty" begin
+        @test union!!(Empty(Set), Empty(Set)) === Empty(Set)
+        @test union!!(Empty(Set), Empty(Vector)) === Empty(Set)
+    end
+end
+
 @testset "mutation" begin
     @testset "Vector" begin
         x = [0.0]


### PR DESCRIPTION
See also #127 for a similar fix for `append!!`
(fe85d807bfb79a2d9416e87534b9fb06d0274993)