### PR TITLE
Fix for mutating `setindex!!` with higher dimensional indices

### DIFF
--- a/test/test_setindex.jl
+++ b/test/test_setindex.jl
@@ -21,4 +21,18 @@ end
     end
 end
 
+@testset "slices" begin
+    x = randn(2, 3)
+    @test @inferred(setindex!!(x, x[:, 1], Base.OneTo(2), 1)) === x
+    @test @inferred(setindex!!(x, x[:, 1], :, 1)) === x
+    @test @inferred(setindex!!(x, x[:], :)) === x
+
+    X = randn(2, 3, 4)
+    @test @inferred(setindex!!(X, X[:, 1, :], :, 1, :)) === X
+    @test @inferred(setindex!!(X, X[:, 1, :], Base.OneTo(2), 1, :)) === X
+    @test @inferred(setindex!!(X, X[:, 1, :], Base.OneTo(2), 1, Base.OneTo(4))) === X
+    @test @inferred(setindex!!(X, X[:, 1, 1], :, 1, 1)) === X
+    @test @inferred(setindex!!(X, X[:], :)) === X
+end
+
 end  # module


### PR DESCRIPTION
Currently, we have the following behavior:

``` julia
julia> x = rand(2, 3);

julia> BangBang.setindex!!(x, ones(2), :, 1)
2×3 Matrix{Any}:
 1.0  0.96169   0.0951699
 1.0  0.799981  0.254469
```

i.e. we hit the immutable version. This is a bug in the current `possible` implementation for `BangBang._setindex!`, which only checks that the `eltype` is valid; in the above case, the `eltype(x)` is of course `Float64` but the element provided `x[:, 1]` is of type `Vector{Float64}`, hence it fails.

In this PR, we have

``` julia
julia> x = rand(2, 3);

julia> BangBang.setindex!!(x, ones(2), :, 1)
2×3 Matrix{Float64}:
 1.0  0.971977  0.761834
 1.0  0.294437  0.529877
```

as desired.